### PR TITLE
Update Battle.js - Shields in charge move decision prior to faint

### DIFF
--- a/src/js/battle/Battle.js
+++ b/src/js/battle/Battle.js
@@ -348,11 +348,12 @@ var BattleMaster = (function () {
 											}
 											
 											// Will a Charged Move knock it out?
+											if(poke.shields == 0){
+												for(var j = 0; j < opponent.chargedMoves.length; j++){
 
-											for(var j = 0; j < opponent.chargedMoves.length; j++){
-
-												if((opponent.energy >= opponent.chargedMoves[j].energy) && (poke.hp <= opponent.chargedMoves[j].damage)){
-													nearDeath = true;
+													if((opponent.energy >= opponent.chargedMoves[j].energy) && (poke.hp <= opponent.chargedMoves[j].damage)){
+														nearDeath = true;
+													}
 												}
 											}
 										}
@@ -380,14 +381,15 @@ var BattleMaster = (function () {
 										}
 										
 										// Can this Pokemon be knocked out by future Charged Moves
+										if(poke.shields == 0){
+											var futureEffectiveEnergy = opponent.energy + (opponent.fastMove.energyGain * futureActions);
+											var futureEffectiveHP = poke.hp - futureActions * opponent.fastMove.damage;
 
-										var futureEffectiveEnergy = opponent.energy + (opponent.fastMove.energyGain * futureActions);
-										var futureEffectiveHP = poke.hp - futureActions * opponent.fastMove.damage;
-										
-										for(var j = 0; j < opponent.chargedMoves.length; j++){
+											for(var j = 0; j < opponent.chargedMoves.length; j++){
 
-											if((futureEffectiveEnergy >= opponent.chargedMoves[j].energy) && (futureEffectiveHP <= opponent.chargedMoves[j].damage)){
-												nearDeath = true;
+												if((futureEffectiveEnergy >= opponent.chargedMoves[j].energy) && (futureEffectiveHP <= opponent.chargedMoves[j].damage)){
+													nearDeath = true;
+												}
 											}
 										}
 									}


### PR DESCRIPTION
Accounting for available shields when checking if Pokemon will be knocked out when making decision about using suboptimal charged move.
Should fix the issue reported here (not tested):
https://www.reddit.com/r/TheSilphArena/comments/aiyij8/why_havent_i_seen_this_pvp_sim_mentioned_here/eetm9gd
where a suboptimal charge move was used