### PR TITLE
Apply Defender Debuff when Deciding Shields

### DIFF
--- a/src/js/battle/Battle.js
+++ b/src/js/battle/Battle.js
@@ -1451,14 +1451,21 @@ function Battle(){
 			if( ((sandbox) && (forceShields) && (defender.shields > 0)) || ((! sandbox) && (defender.shields > 0)) ){
 				var useShield = true;
 
-				// For PuP and similar moves, don't shield if it's survivable
+				// For PuP, Acid Spray and similar moves, don't shield if it's survivable
 
-				if((! sandbox)&&(move.buffs)&&(move.buffs[0] > 0)&&(move.buffApplyChance == 1)){
+				if((! sandbox)&&(move.buffs)&&(move.buffs[0] > 0 || move.buffs[1] < 0)&&(move.buffApplyChance == 1)){
 					useShield = false;
 
 					var postMoveHP = defender.hp - damage; // How much HP will be left after the attack
-					var currentBuffs = [attacker.statBuffs[0], attacker.statBuffs[1]]; // Capture this to reset later
-					attacker.applyStatBuffs(move.buffs);
+					// Capture current buffs for pokemon whose buffs will change
+					var currentBuffs;
+					if (move.buffs[0] > 0) {
+						currentBuffs = [attacker.statBuffs[0], attacker.statBuffs[1]];
+						attacker.applyStatBuffs(move.buffs);
+					} else {
+						currentBuffs = [defender.statBuffs[0], defender.statBuffs[1]];
+						defender.applyStatBuffs(move.buffs);
+					}
 
 					var fastDamage = self.calculateDamage(attacker, defender, attacker.fastMove);
 
@@ -1472,7 +1479,12 @@ function Battle(){
 						useShield = true;
 					}
 
-					attacker.statBuffs = [currentBuffs[0], currentBuffs[1]]; // Reset to original
+					// Reset buffs to original
+					if (move.buffs[0] > 0) {
+						attacker.statBuffs = [currentBuffs[0], currentBuffs[1]];
+					} else {
+						defender.statBuffs = [currentBuffs[0], currentBuffs[1]];
+					}
 
 					// If the defender can't afford to let a charged move connect, block
 


### PR DESCRIPTION
Currently, when deciding to shield or not to shield, if the move buffs the attacker's attack stat, there is a check to see if the defender can survive a cycle.

This same check should be done when the move debuffs the defender's defence stat.