### PR TITLE
Add buff/debuff effects on moves table

### DIFF
--- a/src/js/interface/MovesInterface.js
+++ b/src/js/interface/MovesInterface.js
@@ -62,7 +62,7 @@ var InterfaceMaster = (function () {
 				if(mode == "fast"){
 					headers.push("E", "T", "DPT", "EPT");
 				} else{
-					headers.push("E", "DPE");
+					headers.push("E", "DPE", "Effects");
 				}
 
 				for(var i = 0; i < gm.data.moves.length; i++){
@@ -88,6 +88,7 @@ var InterfaceMaster = (function () {
 					} else if(mode == "charged"){
 						obj.energy = move.energy;
 						obj.dpe = Math.floor( (move.power / move.energy) * 100) / 100;
+						obj.effects = getStatusEffectString(move);
 					}
 
 					// Edge cases
@@ -399,6 +400,36 @@ var InterfaceMaster = (function () {
 				if($(this).hasClass("stab")){
 					self.generateExploreResults(false);
 				}
+			}
+
+			// Get status effect string from move
+			
+			function getStatusEffectString(move){
+				if (!move.buffs) {
+					return '';
+				}
+				var atk = getStatusEffectStatString(move.buffs[0], 'atk');
+				var def = getStatusEffectStatString(move.buffs[1], 'def');
+				var buffApplyChance = parseFloat(move.buffApplyChance)*100 + '%';
+				var buffTarget = move.buffTarget;
+				var stringArray = [buffApplyChance, atk, def, buffTarget];
+				for (var i = 0; i < stringArray.length; i++) {
+					stringArray[i] = "<div>" + stringArray[i] + "</div>";
+				}
+				return stringArray.join('');
+			}
+
+			// Get stats string from move for status effects
+			
+			function getStatusEffectStatString(stat, type){
+				if (stat === 0) {
+					return "";
+				}
+				var statString = stat;
+				if (stat > 0) {
+					statString = "+" + statString;
+				}
+				return statString + " " + type;
 			}
 
 		}

--- a/src/moves.php
+++ b/src/moves.php
@@ -57,7 +57,9 @@ require_once 'header.php';
 			</tr>
 		</table>
 		<input class="poke-search" context="move-search" type="text" placeholder="Search Move or Type" />
-		<table class="sortable-table stats-table moves" cellpadding="0" cellspacing="0"></table>
+		<div class="table-container">
+			<table class="sortable-table stats-table moves" cellpadding="0" cellspacing="0"></table>
+		</div>
 	</div>
 
 	<div class="move-explore-container explore hide">


### PR DESCRIPTION
This PR is a simple addition to the charged moves table, adding the buff/debuff effects column. This also makes it so that the table is horizontally scrollable for mobile devices. 

**Mobile**
![image](https://user-images.githubusercontent.com/24468316/71052462-5a261180-2186-11ea-8d31-df3da3cdc2ec.png)

**Desktop**
![image](https://user-images.githubusercontent.com/24468316/71052491-7033d200-2186-11ea-81df-8846c1dc40a0.png)
