### PR TITLE
List Outrage as a Legacy Move for Salamence

### DIFF
--- a/src/data/gamemaster.json
+++ b/src/data/gamemaster.json
@@ -9123,7 +9123,8 @@
         },
         "types": ["dragon", "flying"],
         "fastMoves": ["BITE", "DRAGON_TAIL", "FIRE_FANG"],
-        "chargedMoves": ["DRACO_METEOR", "FIRE_BLAST", "HYDRO_PUMP", "OUTRAGE"],
+        "chargedMoves": ["DRACO_METEOR", "FIRE_BLAST", "HYDRO_PUMP"],
+        "legacyMoves": ["OUTRAGE"],
         "defaultIVs": {
             "cp1500": [14.5, 12, 6, 15],
             "cp2500": [25.5, 3, 0, 13]


### PR DESCRIPTION
I noticed that Salamence doesn't have Outrage listed as a legacy move, so I added it. Thank you for all the work you put into this amazing tool!