### PR TITLE
update cp for multiselectors

### DIFF
--- a/src/js/training/TrainingSetupInterface.js
+++ b/src/js/training/TrainingSetupInterface.js
@@ -455,6 +455,10 @@ var InterfaceMaster = (function () {
 
 				battle.setCP(cp);
 				battle.setCup(cup);
+				
+				for(var i = 0; i < multiSelectors.length; i++){
+					multiSelectors[i].setCP(cp);
+				}
 
 				// Force featured team selection for Cliffhanger and hide randomize button
 				if(cup == "cliffhanger"){


### PR DESCRIPTION
**Purpose:** The purpose of this work is to have the CP of a team automatically adjust to the league cap when a league is selected in training mode.