### PR TITLE
Added a toggle to display the movesets of Pokemon in the threat list

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2275,6 +2275,11 @@ select, input {
 .article .meta-table .region-label.galar {
   color: #946000;
 }
+.article .threats-table .moveset-label{
+  font-size:10px;
+  font-style: italic;
+  font-weight: normal;
+}
 
 .article-item {
   margin-bottom: 10px;

--- a/src/js/interface/TeamInterface.js
+++ b/src/js/interface/TeamInterface.js
@@ -323,6 +323,7 @@ var InterfaceMaster = (function () {
 				var scorecardCount = parseInt($(".scorecard-length-select option:selected").val());
 				var allowShadows = $(".team-option .check.allow-shadows").hasClass("on");
 				var baitShields = $(".team-option .check.shield-baiting").hasClass("on");
+				var showMovesets = $(".team-option .check.show-movesets").hasClass("on");
 
 				// Get team and validate results
 
@@ -490,8 +491,13 @@ var InterfaceMaster = (function () {
 					}
 
 					// Add results to threats table
+					// If showMovesets is toggled on, add the moveset under the threat's name
 
-					$row = $("<tr><th class=\"name\"><b>"+(count+1)+". "+pokemon.speciesName+"</b></th></tr>");
+					if(showMovesets){
+						$row = $("<tr><th class=\"name\"><b>"+(count+1)+". "+pokemon.speciesName+"</b><br><div class=\"moveset-label\">"+moveNameStr+"</div></tr>");
+					} else {
+						$row = $("<tr><th class=\"name\"><b>"+(count+1)+". "+pokemon.speciesName+"</b></tr>");
+					}
 
 					for(var n = 0; n < r.matchups.length; n++){
 						var $cell = $("<td><a class=\"rating\" href=\"#\" target=\"blank\"><span></span></a></td>");

--- a/src/team-builder.php
+++ b/src/team-builder.php
@@ -55,6 +55,10 @@ require_once 'header.php';
 				<h3>Shield Baiting</h3>
 				<div class="check shield-baiting on"><span></span>Bait shields with low-energy moves</div>
 			</div>
+			<div class="team-option">
+				<h3>Show Threat Movesets</h3>
+				<div class="check show-movesets"><span></span>Show movesets of Pokemon in the threats table</div>
+			</div>
 		</div>
 		<p>Note that links will not currently preserve these advanced settings.</p>
 	</div>


### PR DESCRIPTION
Comparing teams for Sorcerous I wanted to look at how my team handled alternate movesets of specific Pokemon, like Beedrill or Alolan Muk; but the threat list didn't specify the moves of each if they occured multiple times, so I couldn't tell them apart. I added a toggle in the advanced settings to show the moveset under each Pokemon's name in the threat list.

**Changes:**
__TeamInterface.js:__
Added an additional advanced setting for displaying movesets in the threat list (line 326) and a conditional to handle when that's toggled on (line 496)
__team-builder.php:__
Added a new toggle in the advanced settings to toggle threat list movesets on or off (line 58) and also moved the notice about advanced settings not persisting down, out of the div the rest of the options were in. 
__style.css:__
Added text styling for the movesets that appear in the threat list. (line 2278)