### PR TITLE
Disable autocorrect on .poke-search inputs

### DIFF
--- a/src/battle.php
+++ b/src/battle.php
@@ -314,7 +314,7 @@ require_once 'header.php';
 
 		<div class="toggle-content">
 			<div class="poke-search-container">
-				<input class="poke-search" context="ranking-search" type="text" placeholder="Search Pokemon" />
+				<input class="poke-search" context="ranking-search" type="text" placeholder="Search Pokemon" spellcheck="false" autocorrect="off" />
 				<a href="#" class="search-info">i</a>
 
 				<button class="multi-battle-sort">Sort: Worst to best &#9650;</button>

--- a/src/custom-rankings.php
+++ b/src/custom-rankings.php
@@ -160,7 +160,7 @@ require_once 'header.php'; ?>
 	<h3>Rankings</h3>
 
 	<div class="poke-search-container">
-		<input class="poke-search" context="ranking-search" type="text" placeholder="Search Pokemon" />
+		<input class="poke-search" context="ranking-search" type="text" placeholder="Search Pokemon" spellcheck="false" autocorrect="off" />
 		<a href="#" class="search-info">i</a>
 	</div>
 

--- a/src/modules/pokebox.php
+++ b/src/modules/pokebox.php
@@ -12,7 +12,7 @@
 				<a href="https://www.pokebattler.com/pokebox" class="pokebox-edit" target="_blank">Edit Pokebox</a>
 				<a href="https://www.pokebattler.com/user/sponsor/pvpoke" class="pvpoke-sponsor" target="_blank">Sponsor PvPoke</a>
 			</div>
-			<input class="poke-search" context="ranking-search" type="text" placeholder="Search Pokemon" />
+			<input class="poke-search" context="ranking-search" type="text" placeholder="Search Pokemon" spellcheck="false" autocorrect="off" />
 
 			<div class="pokebox-list rankings-container">
 				Loading Pokebox...

--- a/src/modules/pokeselect.php
+++ b/src/modules/pokeselect.php
@@ -1,7 +1,7 @@
 <div class="poke single">
 	<a class="random" href="#">Random</a>
 	<a class="swap" href="#">Swap</a>
-	<input class="poke-search" type="text" placeholder="Search name">
+	<input class="poke-search" type="text" placeholder="Search name" spellcheck="false" autocorrect="off">
 	<select class="poke-select">
 		<option disabled selected value="">Select a Pokemon</option>
 	</select>
@@ -177,7 +177,7 @@
 	<div class="custom-move hide">
 		<p>Add a custom move for <b><span class="name"></span></b>:</p>
 
-		<input class="poke-search" context="move-search" type="text" placeholder="Search move"/>
+		<input class="poke-search" context="move-search" type="text" placeholder="Search move" spellcheck="false" autocorrect="off" />
 		<select class="move-select">
 			<option selected disabled value="">Select a Move</option>
 		</select>

--- a/src/moves.php
+++ b/src/moves.php
@@ -56,7 +56,7 @@ require_once 'header.php';
 				<td>Damage Per Energy</td>
 			</tr>
 		</table>
-		<input class="poke-search" context="move-search" type="text" placeholder="Search Move or Type" />
+		<input class="poke-search" context="move-search" type="text" placeholder="Search Move or Type" spellcheck="false" autocorrect="off" />
 		<div class="table-container">
 			<table class="sortable-table stats-table moves" cellpadding="0" cellspacing="0"></table>
 		</div>
@@ -65,7 +65,7 @@ require_once 'header.php';
 	<div class="move-explore-container explore hide">
 		<div class="move-select-container flex">
 			<div class="move-select-item" >
-				<input class="poke-search" context="move-search" type="text" placeholder="Search move"/>
+				<input class="poke-search" context="move-search" type="text" placeholder="Search move" spellcheck="false" autocorrect="off" />
 				<select class="move-select fast">
 					<option selected disabled value="">Select a Fast Move</option>
 				</select>
@@ -81,7 +81,7 @@ require_once 'header.php';
 				<div class="stab fast check on"><span></span>Same type attack bonus</div>
 			</div>
 			<div class="move-select-item">
-				<input class="poke-search" context="move-search" type="text" placeholder="Search move" />
+				<input class="poke-search" context="move-search" type="text" placeholder="Search move" spellcheck="false" autocorrect="off" />
 				<select class="move-select charged">
 					<option selected disabled value="">Select a Charged Move</option>
 				</select>

--- a/src/pokedex.php
+++ b/src/pokedex.php
@@ -18,7 +18,7 @@ require_once 'header.php';
 
 	<h2 class="loading">Loading data...</h2>
 	<div class="poke-table-container">
-		<input class="poke-search" context="poke-search" type="text" placeholder="Search Move or Type" />
+		<input class="poke-search" context="poke-search" type="text" placeholder="Search Move or Type" spellcheck="false" autocorrect="off" />
 		<table class="sortable-table stats-table pokemon" cellpadding="0" cellspacing="0"></table>
 	</div>
 </div>

--- a/src/rankings.php
+++ b/src/rankings.php
@@ -139,7 +139,7 @@ require_once 'header.php';
 	</div>
 
 	<div class="poke-search-container">
-		<input class="poke-search" context="ranking-search" type="text" placeholder="Search Pokemon" />
+		<input class="poke-search" context="ranking-search" type="text" placeholder="Search Pokemon" spellcheck="false" autocorrect="off" />
 		<a href="#" class="search-info">i</a>
 	</div>
 


### PR DESCRIPTION
When searching for Pokemon/moves on mobile, the inputs can get autocorrected by your OS. This is a mild inconvience since these words most probably aren't in your phone's keyboard dictionary (especially when you're not English).