### PR TITLE
Fix bait bug in team builder

### DIFF
--- a/src/js/battle/TeamRanker.js
+++ b/src/js/battle/TeamRanker.js
@@ -188,7 +188,7 @@ var RankerMaster = (function () {
 
 						pokemon.baitShields = overrideSettings[1].bait;
 
-						if(context == "matrix"){
+						if(context == "matrix" || context == "team-counters"){
 							opponent.baitShields = overrideSettings[0].bait;
 						}
 


### PR DESCRIPTION
Hi!
I fix issue #140. 
The problem was that, although the bait was set false, in the first run my pokemon baited while not in the second one. 
The opponent pokemon had bait set false in both the runs.