### PR TITLE
Add regional tag to klefki

### DIFF
--- a/src/data/gamemaster.json
+++ b/src/data/gamemaster.json
@@ -20824,6 +20824,7 @@
         "types": ["steel", "fairy"],
         "fastMoves": ["ASTONISH", "TACKLE"],
         "chargedMoves": ["FLASH_CANNON", "PLAY_ROUGH", "DRAINING_KISS", "FOUL_PLAY"],
+        "tags": ["regional"],
         "defaultIVs": {
             "cp500": [9.5, 9, 10, 13],
             "cp1500": [29, 6, 15, 8],


### PR DESCRIPTION
I noticed that Klefki was showing up in the Silph Floating City Battleground rankings, so I checked and saw it didn't have the regional tag.