### PR TITLE
runScenario() is sometimes using old values of hp and energy

### DIFF
--- a/src/js/training/TrainingAI.js
+++ b/src/js/training/TrainingAI.js
@@ -628,20 +628,9 @@ function TrainingAI(l, p, b){
 	// Evaluate the current matchup and decide a high level strategy
 
 	this.evaluateMatchup = function(turn, pokemon, opponent, opponentPlayer){
-		// Preserve current HP, energy, and stat boosts
-		pokemon.startHp = pokemon.hp;
-		pokemon.startEnergy = pokemon.energy;
-		pokemon.startStatBuffs = [pokemon.statBuffs[0], pokemon.statBuffs[1]];
-		pokemon.startCooldown = pokemon.cooldown;
-		pokemon.startingShields = pokemon.shields;
 		pokemon.baitShields = true;
 		pokemon.farmEnergy = false;
 
-		opponent.startHp = opponent.hp;
-		opponent.startEnergy = opponent.energy;
-		opponent.startStatBuffs = [opponent.statBuffs[0], opponent.statBuffs[1]];
-		opponent.startCooldown = opponent.cooldown;
-		opponent.startingShields = opponent.shields;
 		opponent.baitShields = true;
 		opponent.farmEnergy = false;
 
@@ -846,6 +835,19 @@ function TrainingAI(l, p, b){
 				index: opponent.index
 			}
 		];
+		
+		// Preserve current HP, energy, and stat boosts which get reset during simulate()
+		pokemon.startHp = pokemon.hp;
+		pokemon.startEnergy = pokemon.energy;
+		pokemon.startStatBuffs = [pokemon.statBuffs[0], pokemon.statBuffs[1]];
+		pokemon.startCooldown = pokemon.cooldown;
+		pokemon.startingShields = pokemon.shields;
+		
+		opponent.startHp = opponent.hp;
+		opponent.startEnergy = opponent.energy;
+		opponent.startStatBuffs = [opponent.statBuffs[0], opponent.statBuffs[1]];
+		opponent.startCooldown = opponent.cooldown;
+		opponent.startingShields = opponent.shields;
 
 		switch(type){
 			case "BOTH_BAIT":


### PR DESCRIPTION
Currently the values of hp and energy are getting changed during calls to simulate, so the simulation AI is making decisions based on inflated HP values and old energy values.  This small pull request sets the correct starting values of these parameters during all calls to runScenario, not just during evaluateMatchup().

This fix appears to resolve an unintentional bug.  The values of hp and energy, along with other stats, are reset to their starting values during simulate, as simulate calls each Pokemon's reset().  The starting values are updated for this at the beginning of each call to evaluateMatchup, which is correct, but there are additional calls to runScenario in other function calls like decideSwitch and decideShield, so the value of HP will briefly be reset to the old value for the duration of those calls to simulate().  Shields and buffs could be affected as well, but those starting values tend to stay updated with only evaluateMatchup in my testing.

The issue appears to be isolated to runScenario().  Other parts of the AI call the HP and energy directly without resetting them, and the stale HP value is currently erased at the end of runScenario().

I tried to come up with an easy example. If facing a Master League lead Kyogre against a team of Melmetal, Yveltal, and Togekiss, after the first matchup, assuming no switch occurs, Kyogre probably has a little HP left.  If the AI overestimates Kyogre's HP and energy then the AI may, depending on the scenario, prefer switching in Yveltal in instead of Togekiss, even though Togekiss is better at farming down a low-HP Pokemon, and is a better switch anyways.

I used a custom AI vs AI simulation to check that this actually improves the AI. The updated AI beats the traditional AI roughly 54% of the time, using a sample of common Great League teams, so this is a minor but measureable improvement to the AI.

There were a few details I wasn't sure of like whether to use "pokemon.startHp =" or "pokemon.setStartingHp()" and whether it's overkill to update shields and buffs as well since they stay pretty in sync in the old version.  Let me know if there are any issues.
