### PR TITLE
Add new settings option to modify the size of custom groups

### DIFF
--- a/src/header.php
+++ b/src/header.php
@@ -48,7 +48,7 @@ if(isset($_COOKIE['settings'])){
 	}
 
 	// Validate the maxPokemonCount, only numbers greater than 1
-	if (!preg_match('/^\d+$/', $_SETTINGS->maxPokemonCount) || intval($_SETTINGS->maxPokemonCount) < 1) {
+	if (!preg_match('/^\d+$/', $_SETTINGS->maxPokemonCount) || intval($_SETTINGS->maxPokemonCount) < 1 || intval($_SETTINGS->maxPokemonCount) > 100000) {
 		$_SETTINGS->maxPokemonCount = 100;
 	}
 

--- a/src/header.php
+++ b/src/header.php
@@ -36,12 +36,22 @@ if(isset($_COOKIE['settings'])){
 		$_SETTINGS->xls = 1;
 	}
 
+	if(! isset($_SETTINGS->maxPokemonCount)){
+		$_SETTINGS->maxPokemonCount = 100;
+	}
+
 	// Validate the gamemaster setting, only allow these options
 	$gamemasters = ["gamemaster", "gamemaster-mega"];
 
 	if(! in_array($_SETTINGS->gamemaster, $gamemasters)){
 		$_SETTINGS->gamemaster = "gamemaster";
 	}
+
+	// Validate the maxPokemonCount, only numbers greater than 1
+	if (!preg_match('/^\d+$/', $_SETTINGS->maxPokemonCount) || intval($_SETTINGS->maxPokemonCount) < 1) {
+		$_SETTINGS->maxPokemonCount = 100;
+	}
+
 } else{
 	$_SETTINGS = (object) [
 		'defaultIVs' => "gamemaster",
@@ -50,7 +60,8 @@ if(isset($_COOKIE['settings'])){
 		'gamemaster' => 'gamemaster',
 		'pokeboxId' => 0,
 		'ads' => 1,
-		'xls' => 1
+		'xls' => 1,
+		'maxPokemonCount' => 100
 	];
 }
 
@@ -131,7 +142,8 @@ if(! isset($OG_IMAGE)){
 			gamemaster: "<?php echo htmlspecialchars($_SETTINGS->gamemaster); ?>",
 			pokeboxId: "<?php echo intval($_SETTINGS->pokeboxId); ?>",
 			pokeboxLastDateTime: "<?php echo intval($_SETTINGS->pokeboxLastDateTime); ?>",
-			xls: <?php echo $_SETTINGS->xls; ?>
+			xls: <?php echo $_SETTINGS->xls; ?>,
+			maxPokemonCount: <?php echo intval($_SETTINGS->maxPokemonCount); ?>
 		};
 	<?php else: ?>
 
@@ -142,7 +154,8 @@ if(! isset($OG_IMAGE)){
 			gamemaster: "gamemaster",
 			pokeboxId: 0,
 			pokeboxLastDateTime: 0,
-			xls: true
+			xls: true,
+			maxPokemonCount: 100
 		};
 
 	<?php endif; ?>

--- a/src/js/interface/CustomRankingInterface.js
+++ b/src/js/interface/CustomRankingInterface.js
@@ -274,7 +274,7 @@ function interfaceObject(){
 
 		var list = [];
 
-		for(var i = 0; i < Math.min(data.length,100); i++){
+		for(var i = 0; i < Math.min(data.length, window.settings.maxPokemonCount); i++){
 			var r = data[i];
 
 			var pokemon = new Pokemon(r.speciesId, 0, battle);

--- a/src/js/interface/PokeMultiSelect.js
+++ b/src/js/interface/PokeMultiSelect.js
@@ -15,8 +15,7 @@ function PokeMultiSelect(element){
 
 	var selectedIndex = -1;
 	var pokeSelector;
-
-	var maxPokemonCount = 100;
+	var maxPokemonCount = window.settings.maxPokemonCount;
 	var selectedGroup = "";
 	var selectedGroupType = "";
 	var pokebox;
@@ -55,6 +54,9 @@ function PokeMultiSelect(element){
 		}
 
 		pokebox = new Pokebox($el.find(".pokebox"), self, "multi", b);
+
+		console.log(window.settings)
+		$el.find(".section-title .poke-max-count").html(window.settings.maxPokemonCount);
 	}
 
 	// Open Pokemon select modal window to add or edit a Pokemon

--- a/src/js/interface/PokeMultiSelect.js
+++ b/src/js/interface/PokeMultiSelect.js
@@ -55,8 +55,7 @@ function PokeMultiSelect(element){
 
 		pokebox = new Pokebox($el.find(".pokebox"), self, "multi", b);
 
-		console.log(window.settings)
-		$el.find(".section-title .poke-max-count").html(window.settings.maxPokemonCount);
+		$el.find(".section-title .poke-max-count").html(maxPokemonCount);
 	}
 
 	// Open Pokemon select modal window to add or edit a Pokemon

--- a/src/js/interface/RankingInterface.js
+++ b/src/js/interface/RankingInterface.js
@@ -212,7 +212,7 @@ var InterfaceMaster = (function () {
 						continue;
 					}
 
-					if(i < 100){
+					if(i < window.settings.maxPokemonCount){
 						metaGroup.push(pokemon);
 					}
 

--- a/src/js/interface/Settings.js
+++ b/src/js/interface/Settings.js
@@ -27,8 +27,13 @@ var InterfaceMaster = (function () {
 				var gamemaster = $("#gm-select option:selected").val();
 				var pokeboxId = $("#pokebox-id").val();
 				var xls = $(".check.xls").hasClass("on") ? 1 : 0;
+				var maxPokemonCount = $("#max-pokemon-count").val();
 
-				console.log(xls);
+				// Make sure cookie is a valid number (as a string)
+				var maxPokemonCountValue = parseInt(maxPokemonCount)
+				if (isNaN(maxPokemonCountValue) || maxPokemonCountValue < 1) {
+					maxPokemonCount = "100"
+				}
 
 				$.ajax({
 
@@ -43,7 +48,8 @@ var InterfaceMaster = (function () {
 						'pokeboxId': pokeboxId,
 						'pokeboxLastDateTime': settings.pokeboxLastDateTime,
 						'ads': ads,
-						'xls': xls
+						'xls': xls,
+						'maxPokemonCount': maxPokemonCount
 					},
 					dataType:'json',
 					success : function(data) {

--- a/src/js/interface/Settings.js
+++ b/src/js/interface/Settings.js
@@ -31,7 +31,7 @@ var InterfaceMaster = (function () {
 
 				// Make sure cookie is a valid number (as a string)
 				var maxPokemonCountValue = parseInt(maxPokemonCount)
-				if (isNaN(maxPokemonCountValue) || maxPokemonCountValue < 1) {
+				if (isNaN(maxPokemonCountValue) || maxPokemonCountValue < 1 || maxPokemonCountValue > 100000) {
 					maxPokemonCount = "100"
 				}
 

--- a/src/settings.php
+++ b/src/settings.php
@@ -75,6 +75,11 @@ require_once 'header.php';
 			</select>
 		</div>
 
+		<h3>Max Custom Group Size</h3>
+		<p>If you would like to use custom groups larger than the default of 100, enter a value below:</p>
+		<input type="text" class="input" id="max-pokemon-count" <?php if(isset($_SETTINGS->maxPokemonCount)) : ?>value="<?php echo intval($_SETTINGS->maxPokemonCount); ?>"<?php endif; ?> />
+		<p>
+
 		<div class="save button">Save Settings</div>
 	</div>
 </div>


### PR DESCRIPTION
Custom group size can now be changed in settings. The value is checked to make sure it is greater than 0 and less than 100000. 

I've been modifying the hardcoded variables in CustomRankingInterface.js, PokeMultiSelect.js, and RankingInterface.js for a little while now, but I thought it would be easier to have it be implemented as a cookie that gets set in settings. 

I'm not sure if this will be too useful for anyone else. But it shouldn't have an impact on anyone unless they change the setting.