### PR TITLE
Pokebox import fix

### DIFF
--- a/src/js/interface/Pokebox.js
+++ b/src/js/interface/Pokebox.js
@@ -144,8 +144,8 @@ function Pokebox(element, selector, selectMode, b){
 				return "jellicent";
 				break;
 
-			case "jellicent_male":
-				return "jellicent";
+			case "frillish_female":
+				return "frillish";
 				break;
 
 			case "gastrodon_east_sea":

--- a/src/js/interface/Pokebox.js
+++ b/src/js/interface/Pokebox.js
@@ -159,6 +159,10 @@ function Pokebox(element, selector, selectMode, b){
 			case "giratina":
 				return "giratina_altered";
 				break;
+
+			case "mewtwo_a":
+				return "mewtwo_armored";
+				break;
 		}
 
 		return id;


### PR DESCRIPTION
Due to the Armored Mewtwo id in Pokebattler's Pokebox being `mewtwo_a` instead of `mewtwo_armored` any users who try import Pokemon with Pokebox that have an Armored Mewtwo will only be able to import Pokemon before that is encountered in the loop as it errors.

Also fixed similar situation with Frillish.