### PR TITLE
Alert on importing NaN

### DIFF
--- a/src/js/interface/PokeMultiSelect.js
+++ b/src/js/interface/PokeMultiSelect.js
@@ -534,10 +534,20 @@ function PokeMultiSelect(element){
 				if(poke.length > 4){
 					pokemon.isCustom = true;
 
-					pokemon.setLevel(parseFloat(poke[4]));
-					pokemon.setIV("atk", parseFloat(poke[5]));
-					pokemon.setIV("def", parseFloat(poke[6]));
-					pokemon.setIV("hp", parseFloat(poke[7]));
+					const level = parseFloat(poke[4]);
+					const atk = parseFloat(poke[5]);
+					const def = parseFloat(poke[6]);
+					const hp = parseFloat(poke[7]);
+
+					// Don't set stats to be NaN
+					if (Number.isNaN(level) || Number.isNaN(atk) || Number.isNaN(def) || Number.isNaN(hp)) {
+						alert("Line " + (i+1) + " has invalid stats: \"" + poke + "\".")
+					} else {
+						pokemon.setLevel(level);
+						pokemon.setIV("atk", atk);
+						pokemon.setIV("def", def);
+						pokemon.setIV("hp", hp);
+					}
 				}
 
 				pokemonList.push(pokemon);

--- a/src/js/interface/PokeMultiSelect.js
+++ b/src/js/interface/PokeMultiSelect.js
@@ -541,7 +541,7 @@ function PokeMultiSelect(element){
 
 					// Don't set stats to be NaN
 					if (Number.isNaN(level) || Number.isNaN(atk) || Number.isNaN(def) || Number.isNaN(hp)) {
-						alert("Line " + (i+1) + " has invalid stats: \"" + poke + "\".")
+						alert("Line " + (i+1) + " has invalid stats: \"" + poke + "\".");
 					} else {
 						pokemon.setLevel(level);
 						pokemon.setIV("atk", atk);


### PR DESCRIPTION
This is a small fix for alerting the user when they import a Pokémon with invalid stats. This could lead to values of NaN being set for level / ivs. 

I noticed this when I was doing a matrix battle like the one below and saw a value of NaN.
<img width="566" alt="multi-nan" src="https://user-images.githubusercontent.com/26497019/206411185-36da2d17-37f4-40c4-aad7-89a5fcd88863.png">

I realized if I imported something like this:
<img width="393" alt="import-input" src="https://user-images.githubusercontent.com/26497019/206411304-b682777c-c7f3-4cc4-826e-b6a01b648404.png">

It would be converted to this:
<img width="398" alt="import-nan" src="https://user-images.githubusercontent.com/26497019/206411380-9fd07ca6-8d75-4c6a-bd34-c23c261cdd6e.png">

This PR prevents NaN values from being used instead of the default from `pokemon.initialize(cp);`, and alerts the user when they have entered an invalid line.

This leads to the stats staying as the initial values.
<img width="397" alt="import-15" src="https://user-images.githubusercontent.com/26497019/206411769-935cca0c-5976-40a2-8504-265a9f020b73.png">

And now the output of the matrix battle no longer contains NaN.
<img width="568" alt="multi" src="https://user-images.githubusercontent.com/26497019/206411883-387c5314-a628-4913-8ae8-bc0aeae54708.png">
