### PR TITLE
Add Fusion Bolt Abbreivation

### DIFF
--- a/src/data/gamemaster/moves.json
+++ b/src/data/gamemaster/moves.json
@@ -856,6 +856,7 @@
 }, {
     "moveId": "FUSION_BOLT",
     "name": "Fusion Bolt",
+    "abbreviation": "FuB",
     "type": "electric",
     "power": 90,
     "energy": 45,


### PR DESCRIPTION
Fusion Bolt and Focus Blast both have the same generated abbreviation of `FB`. I added an override for Fusion Bolt to be `FuB`.