### PR TITLE
Arcana Shadows

### DIFF
--- a/src/data/gamemaster/cups/arcana.json
+++ b/src/data/gamemaster/cups/arcana.json
@@ -8,7 +8,7 @@
     }, {
         "filterType": "id",
         "name": "Species",
-        "values": ["pelipper", "gyarados", "scyther", "vespiquen", "honchkrow"]
+        "values": ["pelipper", "gyarados", "scyther", "vespiquen", "honchkrow", "gyarados_shadow", "scyther_shadow", "honchkrow_shadow"]
     }],
     "exclude": [{
         "filterType": "type",


### PR DESCRIPTION
Shadow versions of Gyarados, Honchkrow, and Scyther were initially left out as the normal versions had to be explicitly allowed.