### PR TITLE
Move Abbreviation Conflicts

### DIFF
--- a/src/data/gamemaster/moves.json
+++ b/src/data/gamemaster/moves.json
@@ -111,6 +111,7 @@
 }, {
     "moveId": "AURA_SPHERE",
     "name": "Aura Sphere",
+    "abbreviation": "AuS",
     "type": "fighting",
     "power": 100,
     "energy": 55,
@@ -557,6 +558,7 @@
 }, {
     "moveId": "DRAIN_PUNCH",
     "name": "Drain Punch",
+    "abbreviation": "DrP",
     "type": "fighting",
     "power": 20,
     "energy": 40,
@@ -802,6 +804,7 @@
 }, {
     "moveId": "FLY",
     "name": "Fly",
+    "abbreviation": "Fl",
     "type": "flying",
     "power": 80,
     "energy": 45,
@@ -970,6 +973,7 @@
 }, {
     "moveId": "HEART_STAMP",
     "name": "Heart Stamp",
+    "abbreviation": "HeS",
     "type": "psychic",
     "power": 40,
     "energy": 40,
@@ -1290,6 +1294,7 @@
 }, {
     "moveId": "INFESTATION",
     "name": "Infestation",
+    "abbreviation": "Inf",
     "type": "bug",
     "power": 6,
     "energy": 0,
@@ -1477,6 +1482,7 @@
     "archetype": "Low Quality"
 }, {
     "moveId": "METEOR_BEAM",
+    "abbreviation": "MeB",
     "name": "Meteor Beam",
     "type": "rock",
     "power": 120,
@@ -1609,6 +1615,7 @@
 }, {
     "moveId": "OBSTRUCT",
     "name": "Obstruct",
+    "abbreviation": "Ob",
     "type": "dark",
     "power": 15,
     "energy": 40,
@@ -1759,6 +1766,7 @@
 }, {
     "moveId": "POLTERGEIST",
     "name": "Poltergeist",
+    "abbreviation": "Po",
     "type": "ghost",
     "power": 140,
     "energy": 75,
@@ -1860,6 +1868,7 @@
     "moveId": "PSYCHIC_FANGS",
     "name": "Psychic Fangs",
     "type": "psychic",
+    "abbreviation": "PsF",
     "power": 40,
     "energy": 35,
     "energyGain": 0,
@@ -2151,6 +2160,7 @@
 }, {
     "moveId": "SHADOW_FORCE",
     "name": "Shadow Force",
+    "abbreviation": "ShF",
     "type": "ghost",
     "power": 120,
     "energy": 90,
@@ -2178,6 +2188,7 @@
     "archetype": "General"
 }, {
     "moveId": "SIGNAL_BEAM",
+    "abbreviation": "SiB",
     "name": "Signal Beam",
     "type": "bug",
     "power": 75,
@@ -2226,6 +2237,7 @@
 }, {
     "moveId": "SLUDGE",
     "name": "Sludge",
+    "abbreviation": "Sl",
     "type": "poison",
     "power": 50,
     "energy": 40,
@@ -2704,6 +2716,7 @@
 }, {
     "moveId": "WRAP_GREEN",
     "name": "Wrap Green",
+    "abbreviation": "WrG",
     "type": "normal",
     "power": 25,
     "energy": 45,
@@ -2713,6 +2726,7 @@
 }, {
     "moveId": "WRAP_PINK",
     "name": "Wrap Pink",
+    "abbreviation": "WrP",
     "type": "normal",
     "power": 25,
     "energy": 45,


### PR DESCRIPTION
Added abbreviations for moves with conflicting autogenerated abbreviations
 - Aura Sphere -> AuS (Acid Spray)
 - Drain Punch -> DrP (Dark Pulse)
 - Fly -> Fl (Frustration)
 - Infestation -> Inf (Incinerate)
 - Meteor Beam -> MeB (Mud Bomb)
 - Obstruct -> Ob (Outrage)
 - Poltergeist -> Po (Psychic)
 - Shadow Force -> ShF (Sacred Fire)
 - Signal Beam -> SiB (Shadow Ball)
 - Wrap Green -> WrG, Wrap Pink -> WrP to match Wrap already at Wr and avoid Wrap Pink conflicting with Water Pulse