### PR TITLE
Update Gimmighoul family buddy distance

### DIFF
--- a/src/data/gamemaster/pokemon.json
+++ b/src/data/gamemaster/pokemon.json
@@ -34014,7 +34014,7 @@
         "cp1500": [50, 15, 15, 15],
         "cp2500": [50, 15, 15, 15]
     },
-    "buddyDistance": 1,
+    "buddyDistance": 5,
     "thirdMoveCost": 10000,
     "released": true,
     "family": {
@@ -34038,7 +34038,7 @@
         "cp1500": [15.5, 6, 12, 15],
         "cp2500": [25.5, 8, 15, 15]
     },
-    "buddyDistance": 1,
+    "buddyDistance": 5,
     "thirdMoveCost": 10000,
     "released": true,
     "family": {


### PR DESCRIPTION
Buddy distance was set to 1km but in game it is 5km.

<img width="375" alt="image" src="https://user-images.githubusercontent.com/26497019/230802425-ef254f54-fc59-418e-98c8-80d6fd1b1096.png">