### PR TITLE
Split search with optional whitespace

### DIFF
--- a/src/js/GameMaster.js
+++ b/src/js/GameMaster.js
@@ -1040,8 +1040,7 @@ var GameMaster = (function () {
 
 		object.generatePokemonListFromSearchString = function(str, battle){
 			// Break the search string up into queries
-			var str = str.replace(/\s+,\s+/g, ',').toLowerCase();
-			var queries = str.split(',');
+			var queries = str.toLowerCase().split(/\s*,\s*/);
 			var results = []; // Store an array of qualifying Pokemon ID's
 
 			var types = ["bug","dark","dragon","electric","fairy","fighting","fire","flying","ghost","grass","ground","ice","normal","poison","psychic","rock","steel","water"];


### PR DESCRIPTION
#227 had an oversight where whitespace was required both before and after. Switched from `+` to `*` for the regex, and splitting directly instead of replacing. Search like `azu , registeel , toxapex` should now show all 3.