### PR TITLE
Speed up searching rankings

### DIFF
--- a/src/js/GameMaster.js
+++ b/src/js/GameMaster.js
@@ -1040,8 +1040,7 @@ var GameMaster = (function () {
 
 		object.generatePokemonListFromSearchString = function(str, battle){
 			// Break the search string up into queries
-			var str = str.replace(/\s+,\s+/g, ',').toLowerCase();
-			var queries = str.split(',');
+			var queries = str.toLowerCase().split(/\s*,\s*/);
 			var results = []; // Store an array of qualifying Pokemon ID's
 
 			var types = ["bug","dark","dragon","electric","fairy","fighting","fire","flying","ghost","grass","ground","ice","normal","poison","psychic","rock","steel","water"];


### PR DESCRIPTION
This depends on the small bug fix in #235 for the search split regex.

I've noticed that searching rankings can be pretty slow at times. This problem has been to be worse on mobile. It also seemed to be slower as more and more terms were entered, such as `a,b,c,d,e,f,g`. 

I added a few `performance.now()` statements in `generatePokemonListFromSearchString` to try to see what was taking so long, and I found that calls to `new Pokemon` were taking up more than 99% of the time spent. I made a few changes to speed up searching:

 - If any of the search terms are empty, just return all Pokémon. No need to loop over any of the queries if you know one of them will return everything.
 - I added the field `object.allPokemon` which is an object that maps a battle cp to a list of Pokémon objects created by calling `new Pokemon` with the given battle.
 - I added the function `object.getAllPokemon` to either generate the list for the given battle, or return the already generated list.
   - Currently, this is only used in `generatePokemonListFromSearchString`, but I imagine it could see use for other places where `new Pokemon` is called multiple times.
 - I added the field `object.searchStringCache` which is an object that maps a search string to a list of species ids that result from that string.
 - If a search has already been tried, just get the results from `object.searchStringCache`.
 - If a new search is entered, set the value of the search to the results before returning.
   - Note: since there is an early return from the function if an empty search term is present, this means that `object.searchStringCache` will not contain massive lists.
 - When iterating over all Pokémon, do not call `new Pokemon`; instead, just loop over the results from `object.getAllPokemon`. 
   - This is the largest speed up, as `new Pokemon` would need to be called potentially tens of thousands of times for m queries (split by `,`) * n Pokémon (currently 1378).