### PR TITLE
improve CSV file name

### DIFF
--- a/src/js/interface/RankingInterface.js
+++ b/src/js/interface/RankingInterface.js
@@ -403,17 +403,27 @@ var InterfaceMaster = (function () {
 				$(".rank").on("click", selectPokemon);
 
 				// Update download link with new data
-				var filename = battle.getCup().name + " Rankings.csv";
+				const cupName = battle.getCup().name;
+				const category = $(".category-select option:selected").val() || scenario.slug;
+				const cpString = `cp${battle.getCP()}`
+
+				const fileNameParts = [cpString,  cupName,  category];
+
+				// var filename = battle.getCup().name + " Rankings.csv";
 				var filedata = '';
 
 				if(context == "custom"){
-					filename = "Custom Rankings.csv";
+					fileNameParts.unshift('custom');
 				}
+
+				const filename = 		fileNameParts.concat( 'rankings.csv').filter(Boolean).join('_');
 
 				if (!csv.match(/^data:text\/csv/i)) {
 					filedata = [csv];
 					filedata = new Blob(filedata, { type: 'text/csv'});
 				}
+
+				debugger;
 
 				$(".button.download-csv").attr("href", window.URL.createObjectURL(filedata));
 				$(".button.download-csv").attr("download", filename);


### PR DESCRIPTION
This relatively simple pull request improves generated CSV file names.

Example new file names:

* `cp1500_evolution_overall_rankings.csv`
* `cp2500_all_overall_rankings.csv`
* `cp2500_weather_switches_rankings.csv`

Master branchs currently always generates name `all Rankings.csv` for open league and eg. `weather Rankings.csv`  for Weather Cup (the same for Ultra League and Great League).