### PR TITLE
Print pokemonList size when ranking

### DIFF
--- a/src/js/battle/RankerSandboxWeightingMoveset.js
+++ b/src/js/battle/RankerSandboxWeightingMoveset.js
@@ -91,7 +91,7 @@ var RankerMaster = (function () {
 
 				}
 
-				console.log("List generated in: " + (Date.now() - startTime) + "ms");
+				console.log("pokemonList [" + pokemonList.length + "] generated in: " + (Date.now() - startTime) + "ms");
 
 			}
 


### PR DESCRIPTION
print the size of `pokemonList` when running ranker to see how many Pokémon are included in the cup.