### PR TITLE
Add search options to limit moves to only fast or charged

### DIFF
--- a/src/js/GameMaster.js
+++ b/src/js/GameMaster.js
@@ -1240,15 +1240,26 @@ var GameMaster = (function () {
 
 							// move name/type serach
 							else {
-								for(var k = 0; k < pokemon.fastMovePool.length; k++){
-									if((pokemon.fastMovePool[k].name.toLocaleLowerCase().startsWith(param))||(pokemon.fastMovePool[k].type == param)){
-										valid = true;
+								const fastOnly = (param.charAt(0) === "1")
+								const chargedOnly = (param.charAt(0) === "2")
+								if (fastOnly || chargedOnly) {
+									param = param.substr(1, param.length-1)
+								}
+								// skip fast moves if @2
+								if (!chargedOnly) {
+									for(var k = 0; k < pokemon.fastMovePool.length; k++){
+										if((pokemon.fastMovePool[k].name.toLocaleLowerCase().startsWith(param))||(pokemon.fastMovePool[k].type == param)){
+											valid = true;
+										}
 									}
 								}
 
-								for(var k = 0; k < pokemon.chargedMovePool.length; k++){
-									if((pokemon.chargedMovePool[k].name.toLocaleLowerCase().startsWith(param))||(pokemon.chargedMovePool[k].type == param)){
-										valid = true;
+								// skip charged moves if @1
+								if (!fastOnly) {
+									for(var k = 0; k < pokemon.chargedMovePool.length; k++){
+										if((pokemon.chargedMovePool[k].name.toLocaleLowerCase().startsWith(param))||(pokemon.chargedMovePool[k].type == param)){
+											valid = true;
+										}
 									}
 								}
 							}


### PR DESCRIPTION
Add more functionality to match the in game search for `@1<type>` or `@2<name>` to allow searching for move name / type in only fast or charged moves.

Examples:
 - `@1grass` for only Pokémon with grass fast moves
 - `@1mud` for only Pokémon with fast moves that start with mud
 - `@2fighting` for only Pokémon with fighting charged moves

Current functionality still works (all grass)
<img width="791" alt="image" src="https://github.com/pvpoke/pvpoke/assets/26497019/209d9b87-86fa-4b64-a735-4ccb77b9728d">

New functionality (fast grass)
<img width="798" alt="image" src="https://github.com/pvpoke/pvpoke/assets/26497019/e13702c5-3c8f-400e-abd4-07217d482efc">

New functionality (charged grass)
<img width="794" alt="image" src="https://github.com/pvpoke/pvpoke/assets/26497019/35e94c26-493b-4527-8468-2ab434b0fbef">
