### PR TITLE
Add "Maximize HP" option

### DIFF
--- a/src/js/interface/PokeMultiSelect.js
+++ b/src/js/interface/PokeMultiSelect.js
@@ -232,6 +232,10 @@ function PokeMultiSelect(element){
 					case "atk":
 						newPokemon.maximizeStat("atk");
 						break;
+						
+					case "hp":
+						newPokemon.maximizeStat("hp");
+						break;
 				}
 
 				pokemonList.push(newPokemon);

--- a/src/js/interface/PokeMultiSelect.js
+++ b/src/js/interface/PokeMultiSelect.js
@@ -200,7 +200,7 @@ function PokeMultiSelect(element){
 			var spreads = ["max"];
 
 			if(battle.getCP() < 10000){
-				spreads.push("def", "atk");
+				spreads.push("def", "atk", "hp");
 			}
 
 			for(var i = 0; i < spreads.length; i++){

--- a/src/modules/pokemultiselect.php
+++ b/src/modules/pokemultiselect.php
@@ -67,6 +67,7 @@
 				<option value="overall">Maximum stat product (Rank 1)</option>
 				<option value="atk">Maximum Attack</option>
 				<option value="def">Maximum Defense</option>
+				<option value="hp">Maximum HP</option>
 			</select>
 			<select class="pokemon-level-cap-select" style="display:none;">
 				<option value="40">Default Level Cap (40)</option>

--- a/src/modules/pokeselect.php
+++ b/src/modules/pokeselect.php
@@ -93,6 +93,7 @@
 				<div class="maximize-section">
 					<div class="check-group">
 						<div class="check on" value="overall"><span></span>Overall</div>
+						<br>
 						<div class="check" value="atk"><span></span>Atk</div>
 						<div class="check" value="def"><span></span>Def</div>
 						<div class="check" value="hp"><span></span>HP</div>

--- a/src/modules/pokeselect.php
+++ b/src/modules/pokeselect.php
@@ -95,6 +95,7 @@
 						<div class="check on" value="overall"><span></span>Overall</div>
 						<div class="check" value="atk"><span></span>Atk</div>
 						<div class="check" value="def"><span></span>Def</div>
+						<div class="check" value="hp"><span></span>HP</div>
 					</div>
 					<div class="level-cap-group">
 						<div>Level Cap:</div>


### PR DESCRIPTION
This adds a "Maximize HP" option in places where it's currently possible to maximize Attack/Defense:

**Poke Select**
<img width="218" alt="image" src="https://github.com/pvpoke/pvpoke/assets/236781/dbeeb8ad-ecf1-4d99-94db-34dfc5568e6b">

**Matrix Battle Default IVs**
<img width="536" alt="image" src="https://github.com/pvpoke/pvpoke/assets/236781/c5bc6a80-473f-4190-98bb-0e61bd5213b2">

It also adds a "Maximum HP" candidate when using the `Add & Compare` function of the Matrix battle.
<img width="201" alt="image" src="https://github.com/pvpoke/pvpoke/assets/236781/daa12200-b145-4ea0-b082-57c5aceedff8">

