### PR TITLE
Change: Remove NaN alert for PokeMultiSelect

### DIFF
--- a/src/js/interface/PokeMultiSelect.js
+++ b/src/js/interface/PokeMultiSelect.js
@@ -543,7 +543,8 @@ function PokeMultiSelect(element){
 
 					// Don't set stats to be NaN
 					if (Number.isNaN(level) || Number.isNaN(atk) || Number.isNaN(def) || Number.isNaN(hp)) {
-						alert("Line " + (i+1) + " has invalid stats: \"" + poke + "\".");
+						// Ignoring the alert here since 3rd party imports may not have IVs/Level
+						// alert("Line " + (i+1) + " has invalid stats: \"" + poke + "\".");
 					} else {
 						pokemon.setLevel(level);
 						pokemon.setIV("atk", atk);


### PR DESCRIPTION
Looking to make it so people can import PvPoke strings into Dracoviz and vice/versa.
However Dracoviz doesn't keep track of IVs, people just report their CP + best buddy status. We also keep track of Purified status, which PvPoke doesn't care about.

My thought is that we can keep these extraneous data as additional list items

For example:
`quagsire_shadow-shadow,MUD_SHOT,AQUA_TAIL,STONE_EDGE,28.5,4,14,10,1494,NO,NO`

where `1494,NO,NO` represents CP, best buddy, purified
Looking at the code and testing it out PvPoke should ignore it, but our problem comes if we don't have an IV/level to give
`quagsire_shadow-shadow,MUD_SHOT,AQUA_TAIL,STONE_EDGE,,,,,1494,NO,NO`
This will trigger the following condition
```
// Don't set stats to be NaN
if (Number.isNaN(level) || Number.isNaN(atk) || Number.isNaN(def) || Number.isNaN(hp)) {
  alert("Line " + (i+1) + " has invalid stats: \"" + poke + "\".");
}
```
Commenting out this condition so that people aren't alerted with every Dracoviz import