### PR TITLE
Fix trait selection requiring extra key press to update

### DIFF
--- a/src/js/interface/PokeSearch.js
+++ b/src/js/interface/PokeSearch.js
@@ -21,7 +21,6 @@ var pokeSearch = new function(){
 		searchStr = $(this).val().toLowerCase().trim();
 		context = $(this).attr("context");
 
-
 		$target = $(e.target).closest(".poke-search-container");
 
 		// Reset the timeout when a new key is typed. This prevents queries from being submitted too quickly and bogging things down on mobile.
@@ -76,6 +75,8 @@ var pokeSearch = new function(){
 		e.preventDefault();
 		modalWindow("Search Traits", $(".search-traits-selector"));
 
+		pokeSearch = e.target.parentElement.querySelector(".poke-search");
+
 		// Populate traits
 		var traits = GameMaster.getInstance().data.pokemonTraits;
 
@@ -89,7 +90,7 @@ var pokeSearch = new function(){
 
 		// Prefill with existing search query
 
-		var searchArr = $(".poke-search").val().split("&");
+		var searchArr = $(pokeSearch).val().split("&");
 
 		for(var i = 0; i < searchArr.length; i++){
 			$(".modal .traits > div[value=\""+searchArr[i]+"\"]").addClass("selected");
@@ -109,8 +110,8 @@ var pokeSearch = new function(){
 				searchArr.push($(this).attr("value"));
 			});
 
-			$(".poke-search").val(searchArr.join("&"));
-			$(".poke-search").trigger("keyup");
+			$(pokeSearch).val(searchArr.join("&"));
+			$(pokeSearch).trigger("keyup");
 
 			closeModalWindow();
 		});


### PR DESCRIPTION
Minor fix but it was annoying me :) To search by traits on the rankings screen...
Before the change:
1) On the rankings screen (any format).
2) Next to Search Pokemon, click (+) to Search Traits e.g. select "Bulky".
3) Ok the Search Traits dialog.
4) You now need to press a key with focus on the textbox to get it to update.

After the change:
Steps 1)-3), but now it updates automatically (no need for step 4).

Technical:
There are multiple poke-search's on the screen (some hidden).
We were grabbing all of them and triggering updates on all of them, so that by the time we ended up at ```submitSearchQuery```, we had the wrong target, so applied the visual update to the wrong poke-search. To the user it appears that the screen didn't update automatically. Now, we will grab the poke-search that was clicked on, so that we always update visuals in the correct place.

Tested on both the ranking screen, and the team builder ("select alternatives") screen.