### PR TITLE
Fix typo in src/data/gamemaster.json -> farigiraf was spelled farigaraf in two separate occasions after the latest commit which reverted the previous fix

### DIFF
--- a/src/data/gamemaster.json
+++ b/src/data/gamemaster.json
@@ -11767,7 +11767,7 @@
         "tags": ["shadoweligible"],
         "family": {
             "id": "FAMILY_GIRAFARIG",
-            "evolutions": ["farigaraf"]
+            "evolutions": ["farigiraf"]
         }
     }, {
         "dex": 203,
@@ -11792,7 +11792,7 @@
         "tags": ["shadow"],
         "family": {
             "id": "FAMILY_GIRAFARIG",
-            "evolutions": ["farigaraf_shadow"]
+            "evolutions": ["farigiraf_shadow"]
         }
     }, {
         "dex": 204,


### PR DESCRIPTION
#301 fixed a typo but commit 858f3859678ea50e077de24267b792ef68723b46 brought it back