### PR TITLE
fix(damage): use accurate floats to calculate damage

### DIFF
--- a/src/js/battle/Battle.js
+++ b/src/js/battle/Battle.js
@@ -250,7 +250,7 @@ function Battle(){
 
 	this.calculateDamageByStats = function(attacker, defender, attack, defense, effectiveness, move){
 
-		var bonusMultiplier = 1.3;
+		var bonusMultiplier = 1.2999999523162841796875;
 
 		var damage = Math.floor(move.power * move.stab * (attack/defense) * effectiveness * 0.5 * bonusMultiplier) + 1;
 
@@ -261,7 +261,7 @@ function Battle(){
 
 	this.calculateBreakpoint = function(attacker, defender, damage, defense, effectiveness, move){
 
-		var bonusMultiplier = 1.3;
+		var bonusMultiplier = 1.2999999523162841796875;
 
 		var attackStatMultiplier = attacker.getStatBuffMultiplier(0, true);
 
@@ -274,7 +274,7 @@ function Battle(){
 
 	this.calculateBulkpoint = function(attacker, defender, damage, attack, effectiveness, move){
 
-		var bonusMultiplier = 1.3;
+		var bonusMultiplier = 1.2999999523162841796875;
 
 		var defenseStatMultiplier = defender.getStatBuffMultiplier(1, true);
 

--- a/src/js/battle/Battle.js
+++ b/src/js/battle/Battle.js
@@ -223,7 +223,7 @@ function Battle(){
 	this.calculateDamage = function(attacker, defender, move, charge){
 		charge = typeof charge !== 'undefined' ? charge : 1;
 
-		var bonusMultiplier = 1.3;
+		var bonusMultiplier = 1.2999999523162841796875;
 		var effectiveness = defender.typeEffectiveness[move.type];
 		var chargeMultiplier = charge; // The amount of charge for a Charged Move
 
@@ -297,7 +297,7 @@ function Battle(){
 			var traits = this.getTypeTraits(type);
 
 			if(traits.weaknesses.indexOf(moveType) > -1){
-				effectiveness *= 1.6;
+				effectiveness *= 1.60000002384185791015625;
 			} else if(traits.resistances.indexOf(moveType) > -1){
 				effectiveness *= .625;
 			} else if(traits.immunities.indexOf(moveType) > -1){

--- a/src/js/pokemon/Pokemon.js
+++ b/src/js/pokemon/Pokemon.js
@@ -621,7 +621,7 @@ function Pokemon(id, i, b){
 
 	this.getStab = function(move){
 		if((move.type == this.types[0]) || (move.type == this.types[1])){
-			return 1.2;
+			return 1.2000000476837158203125;
 		} else{
 			return 1;
 		}


### PR DESCRIPTION
The game uses 32-bit floats to calculate damage instead of 64-bit floats like the simulator suggests. This pull request fixes some cases of this by implementing these floats instead. Notably, this affects the following values and their resultant calculations:

|                                             | "Expected" | Simulation                         | Game                    |
|---------------------------------------------|------------|---------------------------------|---------------------------|
| Doubly Super Effective                      | 2.56       | 2.5600000000000005              | 2.56000007629394          |
| Super Effective                             | 1.6        | 1.60000000000000008881784197001 | 1.60000002384185791015625 |
| Super Effective + Not Very Effective        | 1          | 1                               | 1.0000000149011612        |
| Doubly Not Very Effective + Super Effective | 0.625      | 0.625                           | 0.6250000093132257        |

This pull request, however, does not address the shadow-related constants.