### PR TITLE
Fix broken hover info link in battle.php

### DIFF
--- a/src/battle.php
+++ b/src/battle.php
@@ -88,7 +88,7 @@ require_once 'header.php';
 			<div class="disclaimer">* Results may differ from actual gameplay depending on connectivity, device, player decisions, or other factors.</div>
 		</div>
 		<div class="summary section white"></div>
-		<div class="tip automated">Hover over or tap the timeline for details. <a href="<?php echo $WEB_ROOT; ?>articles/guide-to-fast-move-registration/">Read more</a> about the timeline.</div>
+		<div class="tip automated">Hover over or tap the timeline for details. <a href="<?php echo $WEB_ROOT; ?>articles/strategy/guide-to-fast-move-registration/">Read more</a> about the timeline.</div>
 		<div class="tip sandbox">Click the circles to edit actions.</div>
 	</div>
 


### PR DESCRIPTION
https://pvpoke.com/articles/strategy/guide-to-fast-move-registration/
instead of current broken link to
https://pvpoke.com/articles/guide-to-fast-move-registration/