### PR TITLE
Add fuzzy Pokemon name search

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -105,6 +105,7 @@
 if (strpos($WEB_ROOT, 'src') !== false) : ?>
 
 	<script src="<?php echo $WEB_ROOT; ?>js/GameMaster.js?v=<?php echo $SITE_VERSION; ?>"></script>
+	<script src="<?php echo $WEB_ROOT; ?>js/search/FuzzySearch.js?v=<?php echo $SITE_VERSION; ?>"></script>
 	<script src="<?php echo $WEB_ROOT; ?>js/pokemon/Pokemon.js?v=<?php echo $SITE_VERSION; ?>"></script>
 	<script src="<?php echo $WEB_ROOT; ?>js/interface/HomeInterface.js?v=<?php echo $SITE_VERSION; ?>"></script>
 	<script src="<?php echo $WEB_ROOT; ?>js/interface/ModalWindow.js?v=<?php echo $SITE_VERSION; ?>"></script>
@@ -118,6 +119,7 @@ if (strpos($WEB_ROOT, 'src') !== false) : ?>
 <?php else: ?>
 
 	<script src="<?php echo $WEB_ROOT; ?>js/GameMaster.js?v=<?php echo $SITE_VERSION; ?>"></script>
+	<script src="<?php echo $WEB_ROOT; ?>js/search/FuzzySearch.js?v=<?php echo $SITE_VERSION; ?>"></script>
 	<script src="<?php echo $WEB_ROOT; ?>js/pokemon/Pokemon.js?v=<?php echo $SITE_VERSION; ?>"></script>
 	<script src="<?php echo $WEB_ROOT; ?>js/interface/HomeInterface.js?v=<?php echo $SITE_VERSION; ?>"></script>
 	<script src="<?php echo $WEB_ROOT; ?>js/Main.js?v=<?php echo $SITE_VERSION; ?>"></script>

--- a/src/js/GameMaster.js
+++ b/src/js/GameMaster.js
@@ -1339,9 +1339,13 @@ var GameMaster = (function () {
 		object.generatePokemonListFromSearchString = function(str, battle){
 
 
+			if(! battle){
+				battle = new Battle();
+			}
+
 			// Break the search string up into queries
 			var queries = str.toLowerCase().split(/\s*,\s*/);
-			var searchKey = queries.join() + battle.getCP() + battle.getCup().name;
+			var searchKey = "fuzzy-v1|" + queries.join() + battle.getCP() + battle.getCup().name;
 
 			// don't bother searching if any of the terms are empty
 			// as all pokemon will be valid
@@ -1363,10 +1367,6 @@ var GameMaster = (function () {
 			var metaKey = $(".format-select option:selected").first().attr("meta-group");
 			let rankingKey = battle.getCup().name + "overall" + battle.getCP();
 
-			if(! battle){
-				battle = new Battle();
-			}
-
 			for(var i = 0; i < queries.length; i++){
 				var query = queries[i];
 
@@ -1385,6 +1385,7 @@ var GameMaster = (function () {
 						var param = params[j];
 						var isNot = false;
 						var valid = false;
+						var skipPlainNameSearch = false;
 
 						if(param.length == 0){
 							if(params.length == 1){
@@ -1401,6 +1402,7 @@ var GameMaster = (function () {
 						// Evolution family search
 						if((param.charAt(0) == "+")&&(param.length > 2)){
 							param = param.substr(1, param.length-1);
+							skipPlainNameSearch = true;
 
 							var searchPokemon = object.getPokemonById(param);
 
@@ -1472,11 +1474,6 @@ var GameMaster = (function () {
 								}
 							}
 						} else{
-							// Name search
-							if(pokemon.speciesName.toLowerCase().startsWith(param)){
-								valid = true;
-							}
-
 							// Type search
 							if(pokemon.types.indexOf(param) > -1){
 								valid = true;
@@ -1623,6 +1620,11 @@ var GameMaster = (function () {
 									}
 								}
 							}
+
+							// Name and nickname search
+							if(! valid && ! skipPlainNameSearch && ! isStructuredPokemonSearchParam(param, types, tags, regions)){
+								valid = matchesPokemonNameParam(param, pokemon, isNot);
+							}
 						}
 
 						if(((valid)&&(!isNot))||((!valid)&&(isNot))){
@@ -1638,6 +1640,53 @@ var GameMaster = (function () {
 
 			object.searchStringCache[searchKey] = results
 			return results;
+		}
+
+		function matchesPokemonNameParam(param, pokemon, isNot){
+			var nicknames = pokemon.nicknames || [];
+
+			if(isNot){
+				return pokemon.speciesName.toLowerCase().startsWith(param) || nicknames.indexOf(param) > -1;
+			}
+
+			if(typeof FuzzySearch !== "undefined"){
+				return FuzzySearch.getPokemonNameMatch(param, pokemon).matched;
+			}
+
+			return pokemon.speciesName.toLowerCase().startsWith(param) || nicknames.indexOf(param) > -1;
+		}
+
+		function isStructuredPokemonSearchParam(param, types, tags, regions){
+			// Keep this guard aligned with the structured searches above. It only controls
+			// when fuzzy name matching is allowed, so its patterns are intentionally
+			// stricter than some legacy inline checks like param.indexOf("k") > -1.
+			var exactTerms = ["meta", "xl", "hundo", "4*", "notes"];
+			var structuredLists = [
+				types,
+				tags,
+				object.data.pokemonTraits.pros,
+				object.data.pokemonTraits.cons
+			];
+			var structuredPatterns = [
+				/^\d+$/,
+				/^\d+k$/,
+				/^\d+km$/,
+				/^\d+pts?$/
+			];
+
+			var matchesListTerm = structuredLists.some(function(list){
+				return list.indexOf(param) > -1;
+			});
+
+			var matchesPattern = structuredPatterns.some(function(pattern){
+				return pattern.test(param);
+			});
+
+			var matchesRegion = regions.some(function(region){
+				return param == region.string || param == region.name;
+			});
+
+			return exactTerms.indexOf(param) > -1 || matchesListTerm || matchesPattern || matchesRegion;
 		}
 
 		// Generate a list of moves given a search string

--- a/src/js/GameMaster.js
+++ b/src/js/GameMaster.js
@@ -1345,7 +1345,7 @@ var GameMaster = (function () {
 
 			// Break the search string up into queries
 			var queries = str.toLowerCase().split(/\s*,\s*/);
-			var searchKey = "fuzzy-v1|" + queries.join() + battle.getCP() + battle.getCup().name;
+			var searchKey = queries.join() + battle.getCP() + battle.getCup().name;
 
 			// don't bother searching if any of the terms are empty
 			// as all pokemon will be valid
@@ -1386,6 +1386,7 @@ var GameMaster = (function () {
 						var isNot = false;
 						var valid = false;
 						var skipPlainNameSearch = false;
+						var matchedStructured = false;
 
 						if(param.length == 0){
 							if(params.length == 1){
@@ -1403,6 +1404,7 @@ var GameMaster = (function () {
 						if((param.charAt(0) == "+")&&(param.length > 2)){
 							param = param.substr(1, param.length-1);
 							skipPlainNameSearch = true;
+							matchedStructured = true;
 
 							var searchPokemon = object.getPokemonById(param);
 
@@ -1414,6 +1416,7 @@ var GameMaster = (function () {
 						// Move search
 						if((param.charAt(0) == "@")&&(param.length > 2)){
 							param = param.substr(1, param.length-1);
+							matchedStructured = true;
 
 							// legacy move search
 							if ((param == "legacy")||(param == "special")) {
@@ -1475,13 +1478,19 @@ var GameMaster = (function () {
 							}
 						} else{
 							// Type search
-							if(pokemon.types.indexOf(param) > -1){
-								valid = true;
+							if(types.indexOf(param) > -1){
+								matchedStructured = true;
+								if(pokemon.types.indexOf(param) > -1){
+									valid = true;
+								}
 							}
 
 							// Tag search
-							if((tags.indexOf(param) > -1)&&(pokemon.hasTag(param))){
-								valid = true;
+							if(tags.indexOf(param) > -1){
+								matchedStructured = true;
+								if(pokemon.hasTag(param)){
+									valid = true;
+								}
 							}
 
 							// Nickname search
@@ -1490,13 +1499,18 @@ var GameMaster = (function () {
 							}
 
 							// Dex number search
-
-							if(pokemon.dex == param){
-								valid = true;
+							if(/^\d+$/.test(param)){
+								matchedStructured = true;
+								if(pokemon.dex == param){
+									valid = true;
+								}
 							}
 
 							// Move cost search
 							if(param.indexOf("k") > -1){
+								if(/^\d+k$/.test(param)){
+									matchedStructured = true;
+								}
 								var arr = param.split("k");
 								if(pokemon.thirdMoveCost == parseInt(arr[0]) * 1000){
 									valid = true;
@@ -1505,6 +1519,9 @@ var GameMaster = (function () {
 
 							// Buddy distance search
 							if(param.indexOf("km") > -1){
+								if(/^\d+km$/.test(param)){
+									matchedStructured = true;
+								}
 								var arr = param.split("km");
 								if(pokemon.buddyDistance == parseInt(arr[0])){
 									valid = true;
@@ -1513,6 +1530,7 @@ var GameMaster = (function () {
 
 							// Hundo search
 							if((param == "hundo")||(param == "4*")){
+								matchedStructured = true;
 								pokemon.initialize(true);
 
 								if(pokemon.ivs.atk == 15 && pokemon.ivs.def == 15 && pokemon.ivs.hp == 15){
@@ -1522,6 +1540,7 @@ var GameMaster = (function () {
 
 							// New XL search, no longer a tag
 							if(param == "xl"){
+								matchedStructured = true;
 								if(pokemon.needsXLCandy()){
 									valid = true;
 								}
@@ -1530,6 +1549,7 @@ var GameMaster = (function () {
 							// Region/generation search
 							for(k = 0; k < regions.length; k++){
 								if((param == regions[k].string)||(param==regions[k].name)){
+									matchedStructured = true;
 									if((pokemon.dex >= regions[k].dexStart)&&(pokemon.dex <= regions[k].dexEnd)){
 										valid = true;
 
@@ -1543,6 +1563,9 @@ var GameMaster = (function () {
 
 							// Point/tier search
 							if((param.indexOf("pt") > -1)||(param.indexOf("pts") > -1)){
+								if(/^\d+pts?$/.test(param)){
+									matchedStructured = true;
+								}
 								var val = param.replace("pt","");
 								val = param.replace("pts","");
 								val = parseInt(val);
@@ -1554,6 +1577,7 @@ var GameMaster = (function () {
 
 							// Meta group search
 							if(param == "meta"){
+								matchedStructured = true;
 								if(object.groups[metaKey] !== undefined){
 
 									var group = object.groups[metaKey];
@@ -1571,21 +1595,22 @@ var GameMaster = (function () {
 							}
 
 							// Editor notes search on rankings page
-							
-							if(param == "notes" && window.location.href.indexOf("/rankings/") > -1){
+							if(param == "notes"){
+								matchedStructured = true;
+								if(window.location.href.indexOf("/rankings/") > -1){
+									let $rankEntries = $(".rank[has-editor-notes='true'");
+									$rankEntries.each(function(index, item){
 
-								let $rankEntries = $(".rank[has-editor-notes='true'");
-								$rankEntries.each(function(index, item){
-
-									if(pokemon.speciesId == $(item).attr("data")){
-										valid = true;
-									}
-								});
+										if(pokemon.speciesId == $(item).attr("data")){
+											valid = true;
+										}
+									});
+								}
 							}
 
 							// Trait search
-
 							if((object.data.pokemonTraits.pros.indexOf(param) > -1)||(object.data.pokemonTraits.cons.indexOf(param) > -1)){
+								matchedStructured = true;
 								pokemon.initialize(true);
 								pokemon.selectRecommendedMoveset("overall");
 								var traits = pokemon.generateTraits();
@@ -1622,7 +1647,7 @@ var GameMaster = (function () {
 							}
 
 							// Name and nickname search
-							if(! valid && ! skipPlainNameSearch && ! isStructuredPokemonSearchParam(param, types, tags, regions)){
+							if(!valid && !matchedStructured && !skipPlainNameSearch){
 								valid = matchesPokemonNameParam(param, pokemon, isNot);
 							}
 						}
@@ -1645,6 +1670,7 @@ var GameMaster = (function () {
 		function matchesPokemonNameParam(param, pokemon, isNot){
 			var nicknames = pokemon.nicknames || [];
 
+			// Negated name searches intentionally use exact/prefix matching only so typos do not exclude unexpected Pokemon.
 			if(isNot){
 				return pokemon.speciesName.toLowerCase().startsWith(param) || nicknames.indexOf(param) > -1;
 			}
@@ -1656,40 +1682,7 @@ var GameMaster = (function () {
 			return pokemon.speciesName.toLowerCase().startsWith(param) || nicknames.indexOf(param) > -1;
 		}
 
-		function isStructuredPokemonSearchParam(param, types, tags, regions){
-			// Keep this guard aligned with the structured searches above. It only controls
-			// when fuzzy name matching is allowed, so its patterns are intentionally
-			// stricter than some legacy inline checks like param.indexOf("k") > -1.
-			var exactTerms = ["meta", "xl", "hundo", "4*", "notes"];
-			var structuredLists = [
-				types,
-				tags,
-				object.data.pokemonTraits.pros,
-				object.data.pokemonTraits.cons
-			];
-			var structuredPatterns = [
-				/^\d+$/,
-				/^\d+k$/,
-				/^\d+km$/,
-				/^\d+pts?$/
-			];
-
-			var matchesListTerm = structuredLists.some(function(list){
-				return list.indexOf(param) > -1;
-			});
-
-			var matchesPattern = structuredPatterns.some(function(pattern){
-				return pattern.test(param);
-			});
-
-			var matchesRegion = regions.some(function(region){
-				return param == region.string || param == region.name;
-			});
-
-			return exactTerms.indexOf(param) > -1 || matchesListTerm || matchesPattern || matchesRegion;
-		}
-
-		// Generate a list of moves given a search string
+// Generate a list of moves given a search string
 		object.generateMoveListFromSearchString = function(str){
 
 

--- a/src/js/GameMaster.js
+++ b/src/js/GameMaster.js
@@ -1507,23 +1507,17 @@ var GameMaster = (function () {
 							}
 
 							// Move cost search
-							if(param.indexOf("k") > -1){
-								if(/^\d+k$/.test(param)){
-									matchedStructured = true;
-								}
-								var arr = param.split("k");
-								if(pokemon.thirdMoveCost == parseInt(arr[0]) * 1000){
+							if(/^\d+k$/.test(param)){
+								matchedStructured = true;
+								if(pokemon.thirdMoveCost == parseInt(param) * 1000){
 									valid = true;
 								}
 							}
 
 							// Buddy distance search
-							if(param.indexOf("km") > -1){
-								if(/^\d+km$/.test(param)){
-									matchedStructured = true;
-								}
-								var arr = param.split("km");
-								if(pokemon.buddyDistance == parseInt(arr[0])){
+							if(/^\d+km$/.test(param)){
+								matchedStructured = true;
+								if(pokemon.buddyDistance == parseInt(param)){
 									valid = true;
 								}
 							}
@@ -1562,15 +1556,9 @@ var GameMaster = (function () {
 							}
 
 							// Point/tier search
-							if((param.indexOf("pt") > -1)||(param.indexOf("pts") > -1)){
-								if(/^\d+pts?$/.test(param)){
-									matchedStructured = true;
-								}
-								var val = param.replace("pt","");
-								val = param.replace("pts","");
-								val = parseInt(val);
-
-								if(object.getPokemonTier(pokemon.speciesId, pokemon.getBattle().getCup()) == val){
+							if(/^\d+pts?$/.test(param)){
+								matchedStructured = true;
+								if(object.getPokemonTier(pokemon.speciesId, pokemon.getBattle().getCup()) == parseInt(param)){
 									valid = true;
 								}
 							}

--- a/src/js/interface/PokeSelect.js
+++ b/src/js/interface/PokeSelect.js
@@ -1057,6 +1057,7 @@ function PokeSelect(element, i){
 		}
 
 		var idToSelect;
+		var fuzzyMatches = [];
 
 		for(var i = 0; i < searchArr.length; i++){
 			var pokeName = searchArr[i].speciesName;
@@ -1091,6 +1092,36 @@ function PokeSelect(element, i){
 
 			}
 
+			if(typeof FuzzySearch !== "undefined"){
+				var match = FuzzySearch.getPokemonNameMatch(searchStr, searchArr[i]);
+
+				if(match.matched){
+					fuzzyMatches.push({
+						pokemon: searchArr[i],
+						match: match
+					});
+				}
+			}
+
+		}
+
+		if(! idToSelect && fuzzyMatches.length > 0){
+			fuzzyMatches.sort(function(a, b){
+				if(a.match.score != b.match.score){
+					return a.match.score - b.match.score;
+				}
+
+				if(a.pokemon.priority != b.pokemon.priority){
+					return b.pokemon.priority - a.pokemon.priority;
+				}
+
+				var nameA = a.pokemon.displayName || a.pokemon.speciesName;
+				var nameB = b.pokemon.displayName || b.pokemon.speciesName;
+
+				return nameA > nameB ? 1 : (nameB > nameA ? -1 : 0);
+			});
+
+			idToSelect = fuzzyMatches[0].pokemon.speciesId;
 		}
 
 		var idAlreadySelected = false;

--- a/src/js/interface/PokeSelect.js
+++ b/src/js/interface/PokeSelect.js
@@ -1073,7 +1073,7 @@ function PokeSelect(element, i){
 			}
 
 			if(searchArr[i].nicknames){
-				var nicknameMatched = false;
+				let nicknameMatched = false;
 
 				for(var n = 0; n < searchArr[i].nicknames.length; n++){
 					if(searchArr[i].nicknames[n].startsWith(searchStr)){

--- a/src/js/interface/PokeSelect.js
+++ b/src/js/interface/PokeSelect.js
@@ -1057,26 +1057,23 @@ function PokeSelect(element, i){
 		}
 
 		var idToSelect;
-		var fuzzyMatches = [];
 
+		// Pass 1: exact-style matches — species name prefix, dex number, nickname prefix
 		for(var i = 0; i < searchArr.length; i++){
 			var pokeName = searchArr[i].speciesName;
 
-			// Name search
 			if(pokeName.startsWith(searchStr)){
 				idToSelect = searchArr[i].speciesId;
 				break;
 			}
 
-			// Dex search
 			if(searchArr[i].dex == searchStr){
 				idToSelect = searchArr[i].speciesId;
 				break;
 			}
 
-			// Nickname search
 			if(searchArr[i].nicknames){
-				let nicknameMatched = false;
+				var nicknameMatched = false;
 
 				for(var n = 0; n < searchArr[i].nicknames.length; n++){
 					if(searchArr[i].nicknames[n].startsWith(searchStr)){
@@ -1089,10 +1086,14 @@ function PokeSelect(element, i){
 				if(nicknameMatched){
 					break;
 				}
-
 			}
+		}
 
-			if(typeof FuzzySearch !== "undefined"){
+		// Pass 2: fuzzy matching, only when no exact-style match was found
+		if(!idToSelect && typeof FuzzySearch !== "undefined"){
+			var fuzzyMatches = [];
+
+			for(var i = 0; i < searchArr.length; i++){
 				var match = FuzzySearch.getPokemonNameMatch(searchStr, searchArr[i]);
 
 				if(match.matched){
@@ -1103,25 +1104,24 @@ function PokeSelect(element, i){
 				}
 			}
 
-		}
+			if(fuzzyMatches.length > 0){
+				fuzzyMatches.sort(function(a, b){
+					if(a.match.score != b.match.score){
+						return a.match.score - b.match.score;
+					}
 
-		if(! idToSelect && fuzzyMatches.length > 0){
-			fuzzyMatches.sort(function(a, b){
-				if(a.match.score != b.match.score){
-					return a.match.score - b.match.score;
-				}
+					if(a.pokemon.priority != b.pokemon.priority){
+						return b.pokemon.priority - a.pokemon.priority;
+					}
 
-				if(a.pokemon.priority != b.pokemon.priority){
-					return b.pokemon.priority - a.pokemon.priority;
-				}
+					var nameA = a.pokemon.displayName || a.pokemon.speciesName;
+					var nameB = b.pokemon.displayName || b.pokemon.speciesName;
 
-				var nameA = a.pokemon.displayName || a.pokemon.speciesName;
-				var nameB = b.pokemon.displayName || b.pokemon.speciesName;
+					return nameA > nameB ? 1 : (nameB > nameA ? -1 : 0);
+				});
 
-				return nameA > nameB ? 1 : (nameB > nameA ? -1 : 0);
-			});
-
-			idToSelect = fuzzyMatches[0].pokemon.speciesId;
+				idToSelect = fuzzyMatches[0].pokemon.speciesId;
+			}
 		}
 
 		var idAlreadySelected = false;

--- a/src/js/search/FuzzySearch.js
+++ b/src/js/search/FuzzySearch.js
@@ -22,22 +22,6 @@ var FuzzySearch = new function(){
 		return value.trim();
 	}
 
-	this.tokenize = function(value){
-		value = self.normalize(value);
-
-		if(value == ""){
-			return [];
-		}
-
-		return value.split(" ");
-	}
-
-	this.getEditDistance = function(a, b, maxDistance){
-		a = self.normalize(a);
-		b = self.normalize(b);
-		return getEditDistance(a, b, maxDistance);
-	}
-
 	this.getPokemonNameSearchText = function(pokemon){
 		var signature = getPokemonSearchSignature(pokemon);
 
@@ -60,7 +44,7 @@ var FuzzySearch = new function(){
 			}
 		}
 
-		pokemon._search = {
+		var searchCache = {
 			signature: signature,
 			name: name,
 			compactName: getCompactText(name),
@@ -69,9 +53,16 @@ var FuzzySearch = new function(){
 			compactNicknames: compactNicknames
 		};
 
+		Object.defineProperty(pokemon, "_search", {
+			value: searchCache,
+			writable: true,
+			configurable: true
+		});
+
 		return pokemon._search;
 	}
 
+	// Typo-tolerant plus prefix-aware matching: exact, compact, prefix, token prefix, nickname, and edit-distance variants.
 	this.getPokemonNameMatch = function(param, pokemon){
 		var query = self.normalize(param);
 
@@ -114,8 +105,25 @@ var FuzzySearch = new function(){
 			return createMatch(false, Number.MAX_VALUE, null);
 		}
 
-		var candidates = [searchText.name, searchText.compactName];
-		candidates = candidates.concat(searchText.tokens, searchText.nicknames, searchText.compactNicknames);
+		var seen = {};
+		var candidates = [];
+
+		function addCandidate(str){
+			if(str && str != "" && !seen[str]){
+				seen[str] = true;
+				candidates.push(str);
+			}
+		}
+
+		addCandidate(searchText.name);
+		addCandidate(searchText.compactName);
+		for(var i = 0; i < searchText.tokens.length; i++){
+			addCandidate(searchText.tokens[i]);
+		}
+		for(var i = 0; i < searchText.nicknames.length; i++){
+			addCandidate(searchText.nicknames[i]);
+			addCandidate(searchText.compactNicknames[i]);
+		}
 
 		var bestDistance = maxDistance + 1;
 

--- a/src/js/search/FuzzySearch.js
+++ b/src/js/search/FuzzySearch.js
@@ -53,16 +53,11 @@ var FuzzySearch = new function(){
 			compactNicknames: compactNicknames
 		};
 
-		Object.defineProperty(pokemon, "_search", {
-			value: searchCache,
-			writable: true,
-			configurable: true
-		});
+		pokemon._search = searchCache;
 
 		return pokemon._search;
 	}
 
-	// Typo-tolerant plus prefix-aware matching: exact, compact, prefix, token prefix, nickname, and edit-distance variants.
 	this.getPokemonNameMatch = function(param, pokemon){
 		var query = self.normalize(param);
 

--- a/src/js/search/FuzzySearch.js
+++ b/src/js/search/FuzzySearch.js
@@ -1,0 +1,244 @@
+// Dependency-free helpers for typo-tolerant Pokemon name search.
+
+var FuzzySearch = new function(){
+	var self = this;
+
+	this.normalize = function(value){
+		if(value === undefined || value === null){
+			return "";
+		}
+
+		value = String(value).toLowerCase().trim();
+
+		if(value.normalize){
+			value = value.normalize("NFD");
+		}
+
+		value = value.replace(/[\u0300-\u036f]/g, "");
+		value = value.replace(/['’`._\-()]/g, " ");
+		value = value.replace(/[^\w\s]/g, " ");
+		value = value.replace(/\s+/g, " ");
+
+		return value.trim();
+	}
+
+	this.tokenize = function(value){
+		value = self.normalize(value);
+
+		if(value == ""){
+			return [];
+		}
+
+		return value.split(" ");
+	}
+
+	this.getEditDistance = function(a, b, maxDistance){
+		a = self.normalize(a);
+		b = self.normalize(b);
+		return getEditDistance(a, b, maxDistance);
+	}
+
+	this.getPokemonNameSearchText = function(pokemon){
+		var signature = getPokemonSearchSignature(pokemon);
+
+		if(pokemon._search && pokemon._search.signature == signature){
+			return pokemon._search;
+		}
+
+		var name = self.normalize(pokemon.speciesName || pokemon.displayName || "");
+		var nicknames = [];
+		var compactNicknames = [];
+
+		if(pokemon.nicknames){
+			for(var i = 0; i < pokemon.nicknames.length; i++){
+				var nickname = self.normalize(pokemon.nicknames[i]);
+
+				if(nickname != ""){
+					nicknames.push(nickname);
+					compactNicknames.push(getCompactText(nickname));
+				}
+			}
+		}
+
+		pokemon._search = {
+			signature: signature,
+			name: name,
+			compactName: getCompactText(name),
+			tokens: name == "" ? [] : name.split(" "),
+			nicknames: nicknames,
+			compactNicknames: compactNicknames
+		};
+
+		return pokemon._search;
+	}
+
+	this.getPokemonNameMatch = function(param, pokemon){
+		var query = self.normalize(param);
+
+		if(query == ""){
+			return createMatch(false, Number.MAX_VALUE, null);
+		}
+
+		var compactQuery = getCompactText(query);
+		var searchText = self.getPokemonNameSearchText(pokemon);
+
+		if(query == searchText.name || compactQuery == searchText.compactName){
+			return createMatch(true, 0, "exact");
+		}
+
+		for(var i = 0; i < searchText.nicknames.length; i++){
+			if(query == searchText.nicknames[i] || compactQuery == searchText.compactNicknames[i]){
+				return createMatch(true, 0, "nickname");
+			}
+		}
+
+		if(searchText.name.startsWith(query) || searchText.compactName.startsWith(compactQuery)){
+			return createMatch(true, 1, "prefix");
+		}
+
+		for(var i = 0; i < searchText.tokens.length; i++){
+			if(searchText.tokens[i].startsWith(query)){
+				return createMatch(true, 2, "token-prefix");
+			}
+		}
+
+		for(var i = 0; i < searchText.nicknames.length; i++){
+			if(searchText.nicknames[i].startsWith(query) || searchText.compactNicknames[i].startsWith(compactQuery)){
+				return createMatch(true, 3, "nickname");
+			}
+		}
+
+		var maxDistance = getMaxDistance(compactQuery.length);
+
+		if(maxDistance == 0){
+			return createMatch(false, Number.MAX_VALUE, null);
+		}
+
+		var candidates = [searchText.name, searchText.compactName];
+		candidates = candidates.concat(searchText.tokens, searchText.nicknames, searchText.compactNicknames);
+
+		var bestDistance = maxDistance + 1;
+
+		for(var i = 0; i < candidates.length; i++){
+			var candidate = candidates[i];
+
+			if(candidate == ""){
+				continue;
+			}
+
+			var candidateQuery = candidate.indexOf(" ") > -1 ? query : compactQuery;
+			var distance = getEditDistance(candidateQuery, candidate, maxDistance);
+
+			if(distance <= maxDistance && passesFuzzyGuard(compactQuery, candidate, distance)){
+				if(distance < bestDistance){
+					bestDistance = distance;
+				}
+			}
+		}
+
+		if(bestDistance <= maxDistance){
+			return createMatch(true, 10 + bestDistance, "fuzzy");
+		}
+
+		return createMatch(false, Number.MAX_VALUE, null);
+	}
+
+	function getEditDistance(a, b, maxDistance){
+		if(a == b){
+			return 0;
+		}
+
+		if(maxDistance === undefined){
+			maxDistance = Math.max(a.length, b.length);
+		}
+
+		if(Math.abs(a.length - b.length) > maxDistance){
+			return maxDistance + 1;
+		}
+
+		if(a.length == 0){
+			return b.length;
+		}
+
+		if(b.length == 0){
+			return a.length;
+		}
+
+		var previous = [];
+		var current = [];
+
+		for(var i = 0; i <= b.length; i++){
+			previous[i] = i;
+		}
+
+		for(var i = 1; i <= a.length; i++){
+			current[0] = i;
+			var rowMin = current[0];
+
+			for(var j = 1; j <= b.length; j++){
+				var cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+
+				current[j] = Math.min(
+					previous[j] + 1,
+					current[j - 1] + 1,
+					previous[j - 1] + cost
+				);
+
+				if(current[j] < rowMin){
+					rowMin = current[j];
+				}
+			}
+
+			if(rowMin > maxDistance){
+				return maxDistance + 1;
+			}
+
+			var temp = previous;
+			previous = current;
+			current = temp;
+		}
+
+		return previous[b.length];
+	}
+
+	function getCompactText(value){
+		return self.normalize(value).replace(/\s/g, "");
+	}
+
+	function getPokemonSearchSignature(pokemon){
+		var nicknames = pokemon.nicknames ? pokemon.nicknames.join("|") : "";
+		return (pokemon.speciesName || pokemon.displayName || "") + "|" + nicknames;
+	}
+
+	function getMaxDistance(length){
+		if(length < 3){
+			return 0;
+		}
+
+		if(length == 3){
+			return 1;
+		}
+
+		if(length <= 10){
+			return 2;
+		}
+
+		return 3;
+	}
+
+	function passesFuzzyGuard(query, candidate, distance){
+		if(query.charAt(0) == candidate.charAt(0)){
+			return true;
+		}
+
+		return query.length >= 6 && distance == 1;
+	}
+
+	function createMatch(matched, score, type){
+		return {
+			matched: matched,
+			score: score,
+			type: type
+		};
+	}
+};

--- a/src/modules/scripts/battle-scripts.php
+++ b/src/modules/scripts/battle-scripts.php
@@ -1,3 +1,4 @@
+<script src="<?php echo $WEB_ROOT; ?>js/search/FuzzySearch.js?v=<?php echo $SITE_VERSION; ?>"></script>
 <script src="<?php echo $WEB_ROOT; ?>js/battle/DamageCalculator.js?v=<?php echo $SITE_VERSION; ?>"></script>
 <script src="<?php echo $WEB_ROOT; ?>js/battle/actions/ActionLogic.js?v=<?php echo $SITE_VERSION; ?>"></script>
 <script src="<?php echo $WEB_ROOT; ?>js/battle/timeline/TimelineEvent.js?v=<?php echo $SITE_VERSION; ?>"></script>

--- a/src/modules/search-string-help.php
+++ b/src/modules/search-string-help.php
@@ -1,5 +1,6 @@
 <div class="sandbox-search-strings article hide">
 	<p>You can use the following search formats to filter Pokemon:</p>
+	<p>Pokemon name searches tolerate minor typos.</p>
 	<table cellspacing="0">
 		<tr>
 			<td><strong>Pokemon Name</strong></td>

--- a/src/train/analytics.php
+++ b/src/train/analytics.php
@@ -45,6 +45,7 @@ require_once '../header.php';
 </div>
 
 <script src="<?php echo $WEB_ROOT; ?>js/GameMaster.js?v=<?php echo $SITE_VERSION; ?>"></script>
+<script src="<?php echo $WEB_ROOT; ?>js/search/FuzzySearch.js?v=<?php echo $SITE_VERSION; ?>"></script>
 <script src="<?php echo $WEB_ROOT; ?>js/pokemon/Pokemon.js?v=<?php echo $SITE_VERSION; ?>"></script>
 <script src="<?php echo $WEB_ROOT; ?>js/pokemon/Player.js?v=<?php echo $SITE_VERSION; ?>"></script>
 <script src="<?php echo $WEB_ROOT; ?>js/training/TrainingAnalytics.js?v=<?php echo $SITE_VERSION; ?>"></script>


### PR DESCRIPTION
## Summary
- add a dependency-free fuzzy Pokemon name search helper
- wire typo-tolerant name matching into ranking, battle, team builder, and related Pokemon search flows
- keep structured search terms exact and preserve existing ranking order

## Validation
<img width="1684" height="830" alt="image" src="https://github.com/user-attachments/assets/cae24092-6288-400d-9219-e9d9c9099c31" />
<img width="300" height="500" alt="Screenshot 2026-05-11 at 12 09 27 PM" src="https://github.com/user-attachments/assets/10ec3f00-75f6-44b9-bcdf-68f79ba4cc70" />
