### PR TITLE
Fix Team Builder Meta Scorecard printing

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -6655,7 +6655,7 @@ iframe#bh-div {
 .scorecard-print .toggle-content {
     display: none !important;
   }
-  .scorecard-print .toggle-content:nth-of-type(1) {
+  .scorecard-print .toggle-content.meta-scorecard {
     display: block !important;
   }
   .scorecard-print .article .rating-table a {

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -7255,7 +7255,7 @@ iframe#bh-div {
 			display:none !important;
 		}
 
-		.toggle-content:nth-of-type(1){
+		.toggle-content.meta-scorecard{
 			display:block !important;
 		}
 

--- a/src/team-builder.php
+++ b/src/team-builder.php
@@ -176,7 +176,7 @@ require_once 'header.php';
 		</div>
 	</div>
 	<a href="#" class="toggle active">Meta Scorecard <span class="arrow-down">&#9660;</span><span class="arrow-up">&#9650;</span></a>
-	<div class="toggle-content article">
+	<div class="toggle-content article meta-scorecard">
 		<p>Explore how the top ranked Pokemon match up against your team below. Print this scorecard or save a screenshot for reference as you practice. Remember to prepare beforehand and follow timely play in tournaments!</p>
 		<div class="table-container">
 			<table class="meta-table rating-table" cellspacing="0">


### PR DESCRIPTION
## Summary

- mark the Meta Scorecard result panel with a semantic class
- target that panel directly in print styles instead of relying on sibling position
- keep the maintained SCSS source and generated CSS synchronized

The previous `:nth-of-type(1)` selector resolves to the Overview panel in the current Team Builder markup, so the print button displays the wrong content.

Fixes #377.

## Validation

- built and ran the documented Docker environment
- added Altaria, rated the team, and confirmed the Meta Scorecard populated with 21 rows
- invoked Print and confirmed the live print stylesheet targets only the Meta Scorecard
- checked a 390×844 mobile viewport with no horizontal overflow
- ran `php -l` and `apache2ctl -t`
- compiled `src/css/style.scss`
- ran `git diff --check`